### PR TITLE
fix a bug in File.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "peynman/laravel-plupload",
     "description": "Plupload package for Laravel 5",
+    "version": "3.1",
     "keywords": [
         "laravel",
         "plupload"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jenky/laravel-plupload",
+    "name": "peynman/laravel-plupload",
     "description": "Plupload package for Laravel 5",
     "keywords": [
         "laravel",

--- a/src/File.php
+++ b/src/File.php
@@ -114,7 +114,7 @@ class File
         $this->appendData($filePath, $file);
 
         if ($chunk == $chunks - 1) {
-            $file = new UploadedFile($filePath, $originalName, 'blob', count($filePath), UPLOAD_ERR_OK, true);
+            $file = new UploadedFile($filePath, $originalName, 'blob', UPLOAD_ERR_OK, true);
             @unlink($filePath);
 
             return $closure($file);

--- a/src/File.php
+++ b/src/File.php
@@ -115,7 +115,6 @@ class File
 
         if ($chunk == $chunks - 1) {
             $file = new UploadedFile($filePath, $originalName, 'blob', UPLOAD_ERR_OK, true);
-            @unlink($filePath);
 
             return $closure($file);
         }


### PR DESCRIPTION
when uploading a single file and using the provided Plupload::file method the $upload object return to closure is deleted (unlinked) before calling the closure, this way files cant be moved to other pathes.